### PR TITLE
gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+## optional config to try this out in gitpod
+## feel free to delete
 ports:
 - port: 8000
   onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 8000
+  onOpen: open-preview
+tasks:
+- init: yarn install
+  command: yarn develop

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ More information in the blogpost: https://www.netlify.com/blog/2017/07/20/how-to
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/sw-yx/gatsby-netlify-form-example-v2)
 
+## Start Coding
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## reCAPTCHA
 
 This example site uses [react-google-recaptcha](https://github.com/dozoisch/react-google-recaptcha) to render the reCAPTCHA widget.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ More information in the blogpost: https://www.netlify.com/blog/2017/07/20/how-to
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/sw-yx/gatsby-netlify-form-example-v2)
 
-## Start Coding
+## Try it out in Gitpod
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 


### PR DESCRIPTION
Hi 👋 
I just stumbled over the gatsby + netlify website and ended up on this repo.
Adding a little support for gitpod will allow people to get started coding on this project more easily.

I've configured it so it start gatsby develop and open the website in the preview. 
People can start playing around and create a fork from within the IDE (this is how I made this PR).

You can try it on this PR 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

<img width="1487" alt="Screenshot 2019-08-09 at 18 07 58" src="https://user-images.githubusercontent.com/372735/62793145-200a7c00-bad1-11e9-86b0-422fa5ec2e52.png">

P.S.: I'm a co-founder of gitpod and a big fan of netlify and gatsby :)
